### PR TITLE
Add more complete support for a remote name other than origin

### DIFF
--- a/lib/git_bpf/commands/init.rb
+++ b/lib/git_bpf/commands/init.rb
@@ -80,11 +80,13 @@ class Init < GitFlow/'init'
     target.config(true, "rerere.enabled", "true")
     target.config(true, "rerere.autoupdate", "true")
 
+    target.config(true, "gitbpf.remotename", opts.remote_name)
+
     rerere_path = File.join(target.git_dir, 'rr-cache')
     target_remote_url = target.remoteUrl(opts.remote_name)
 
     if not File.directory? rerere_path
-      rerere = Repository::clone target_remote_url, rerere_path
+      rerere = Repository::clone target_remote_url, rerere_path, opts.remote_name
     elsif not File.directory? File.join(rerere_path, '.git')
       opoo "Rerere cache directory already exists; Initializing repository in existing rr-cache directory."
       rerere = Repository.init rerere_path

--- a/lib/git_bpf/hooks/post-checkout.rb
+++ b/lib/git_bpf/hooks/post-checkout.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
 
 # Pull latest conflict resolutions.
-`git share-rerere pull`
+remote_name = `git config --get gitbpf.remotename`.chomp
+`git share-rerere pull -r #{remote_name}`

--- a/lib/git_bpf/hooks/post-merge.rb
+++ b/lib/git_bpf/hooks/post-merge.rb
@@ -6,6 +6,7 @@ parents = `git rev-list -n 1 --parents HEAD`.split("\s")
 last = parents.shift
 
 if parents.length >= 2
-  `git share-rerere pull`
-  `git share-rerere push`
+  remote_name = `git config --get gitbpf.remotename`.chomp
+  `git share-rerere pull -r #{remote_name}`
+  `git share-rerere push -r #{remote_name}`
 end

--- a/lib/git_bpf/lib/repository.rb
+++ b/lib/git_bpf/lib/repository.rb
@@ -86,8 +86,8 @@ class Repository
     return true
   end
 
-  def self.clone(url, dest)
-    git('clone', url, dest)
+  def self.clone(url, dest, name = 'origin')
+    git('clone', '-o', name, url, dest)
     Repository.new dest
   end
 


### PR DESCRIPTION
While it is already possible to initialize git-bpf specifying a remote name other than origin, the hooks for pulling and pushing rereres assume the origin remote. It would be nice to have complete support for a non-origin remote name.

This approach uses a config setting for the remote name, which gets set on init.
