### PR TITLE
Error out gracefully if the gitbpf.remotename config hasn't been set

### DIFF
--- a/lib/git_bpf/hooks/post-checkout.rb
+++ b/lib/git_bpf/hooks/post-checkout.rb
@@ -2,4 +2,8 @@
 
 # Pull latest conflict resolutions.
 remote_name = `git config --get gitbpf.remotename`.chomp
+if remote_name.empty?
+  STDERR.puts "You have not configured the remote repository to be used by git-bpf. This is needed for rerere sharing. To use the 'origin' remote, run \n \`git config gitbpf.remotename 'origin'\`\n You can specify a remote name of your choosing."
+  exit 1
+end
 `git share-rerere pull -r #{remote_name}`

--- a/lib/git_bpf/hooks/post-merge.rb
+++ b/lib/git_bpf/hooks/post-merge.rb
@@ -7,6 +7,10 @@ last = parents.shift
 
 if parents.length >= 2
   remote_name = `git config --get gitbpf.remotename`.chomp
+  if remote_name.empty?
+    STDERR.puts "You have not configured the remote repository to be used by git-bpf. This is needed for rerere sharing. To use the 'origin' remote, run \n \`git config gitbpf.remotename 'origin'\`\n You can specify a remote name of your choosing."
+    exit 1
+  end
   `git share-rerere pull -r #{remote_name}`
   `git share-rerere push -r #{remote_name}`
 end


### PR DESCRIPTION
Follow-up to adding support for non-origin remotes. Anyone who has already initialized a repo to use git-bpf and upgrades to this will get a nasty error whenever they perform a checkout or merge.
