### PR TITLE
Idempotent init command

### DIFF
--- a/lib/git_bpf/commands/init.rb
+++ b/lib/git_bpf/commands/init.rb
@@ -30,6 +30,15 @@ class Init < GitFlow/'init'
     ]
   end
 
+  # Removes all aliases to git-bpf commands.
+  def removeCommandAliases(repo)
+    config = repo.config(true, '--list').lines.each do |line|
+      next unless line.start_with? 'alias.' and line.match /\!_git\-bpf/
+      a = /alias\.([a-zA-Z0-9\-_]+)\=(.)*/.match(line)[1]
+      repo.config(true, '--unset', "alias.#{a}")
+    end
+  end
+
   # Removes all symlinks to targets within source_location that are found
   # within path.
   def rmSymlinks(path, source_location)
@@ -76,6 +85,7 @@ class Init < GitFlow/'init'
 
     # Perform some cleanup in case this repo was previously initalized.
     target.config(true, '--remove-section', 'gitbpf') rescue nil
+    removeCommandAliases target
     rmSymlinks(target.git_dir, source_path)
 
     #

--- a/lib/git_bpf/commands/init.rb
+++ b/lib/git_bpf/commands/init.rb
@@ -1,6 +1,7 @@
 require 'git_bpf/lib/gitflow'
 require 'git_bpf/lib/git-helpers'
 require 'git_bpf/lib/repository'
+require 'Find'
 
 #
 # init: 
@@ -29,16 +30,52 @@ class Init < GitFlow/'init'
     ]
   end
 
+  # Removes all symlinks to targets within source_location that are found
+  # within path.
+  def rmSymlinks(path, source_location)
+    targets_to_check = [source_location]
+    all_targets = []
+
+    # Find all symlink targets that represent a path within source_location.
+    while targets_to_check.length > 0
+      git_bpf_target = targets_to_check.pop
+      Find.find(path) do |p|
+        if File.symlink?(p)
+          target =  File.readlink(p)
+          if target.include? git_bpf_target and not targets_to_check.include? p
+            targets_to_check.push p
+          end
+        end
+      end
+      all_targets.push git_bpf_target
+    end
+
+    # Now delete any symlink whose target path includes any of the paths we
+    # have identified.
+    Find.find(path) do |p|
+      if File.symlink? p
+        target = File.readlink p
+        all_targets.each do |t|
+          if target.include? t
+            File.unlink p
+            break
+          end
+        end
+      end
+    end
+  end
+
   def execute(opts, argv)
     if argv.length > 1
       run 'init', '--help'
       terminate
     end
 
-    # TODO: There's likely a better way to do this.
-    source_path = File.join File.dirname(__FILE__), '..'
+    source_path = File.expand_path("..", File.dirname(__FILE__))
     target = Repository.new(argv.length == 1 ? argv.pop : Dir.getwd)
 
+    # First remove any existing symlinks to the git_bpf source
+    rmSymlinks(target.git_dir, source_path)
 
     #
     # 1. Link source scripts directory.

--- a/lib/git_bpf/commands/init.rb
+++ b/lib/git_bpf/commands/init.rb
@@ -74,7 +74,8 @@ class Init < GitFlow/'init'
     source_path = File.expand_path("..", File.dirname(__FILE__))
     target = Repository.new(argv.length == 1 ? argv.pop : Dir.getwd)
 
-    # First remove any existing symlinks to the git_bpf source
+    # Perform some cleanup in case this repo was previously initalized.
+    target.config(true, '--remove-section', 'gitbpf') rescue nil
     rmSymlinks(target.git_dir, source_path)
 
     #


### PR DESCRIPTION
These changes make it possible to run git-bpf-init on a repo any number of times and the state of the repo will be as if it was run for the first time using the latest git-bpf code. It does this by removing any existing symlinks to targets within the git-bpf source location, removing aliases to git-bpf commands from the local git config, and removing the gitbpf section of the local git config.
The one assumption is that there will never be any reason to alter the way the rr-cache directory has been set up - this is just left alone if the repo was previously initialized for git-bpf.
