### PR TITLE
Allow the source branch to be newly grabbed from the remote instead of a...

### DIFF
--- a/lib/git_bpf/lib/git-helpers.rb
+++ b/lib/git_bpf/lib/git-helpers.rb
@@ -83,8 +83,12 @@ module GitHelpersMixin
     return params + args
   end
 
-  def branchExists?(branch)
-    ref = (branch.include? "refs/heads/") ? branch : "refs/heads/#{branch}"
+  def branchExists?(branch, remote = nil)
+    if remote
+      ref = "refs/remotes/#{remote}/#{branch}"
+    else
+      ref = (branch.include? "refs/heads/") ? branch : "refs/heads/#{branch}"
+    end
     begin
       git('show-ref', '--verify', '--quiet', ref)
     rescue


### PR DESCRIPTION
...ssuming the local branch is up to date

Open to suggestions for a better option than -d, --discard :-/
