### PR TITLE
Adding a white-list of branch names

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A collection of commands to help share your rr-cache.
         -g, --git-dir DIR                The location of your rr-cache .git dir, defaults to .git/rr-cache/.git.
         -b, --branch NAME                The name of the branch your rr-cache is stored in, defaults to rr-cache.
         -r, --remote NAME                The name of the remote to use when getting the latest rr-cache, defaults to origin.
-        -w, --whitelist-file-name NAME'	 Specify the white list file of a carriage-return delimited list of branch names to whitelist.
+        -w, --whitelist-file-name NAME	 Specify the white list file of a carriage-return delimited list of branch names to whitelist.
 
 **Sub-commands - Usage:**
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A collection of commands to help share your rr-cache.
         -g, --git-dir DIR                The location of your rr-cache .git dir, defaults to .git/rr-cache/.git.
         -b, --branch NAME                The name of the branch your rr-cache is stored in, defaults to rr-cache.
         -r, --remote NAME                The name of the remote to use when getting the latest rr-cache, defaults to origin.
-	-w, --whitelist-file-name NAME'	 Specify the white list file of a carriage-return delimited list of branch names to whitelist.
+        -w, --whitelist-file-name NAME'	 Specify the white list file of a carriage-return delimited list of branch names to whitelist.
 
 **Sub-commands - Usage:**
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A collection of commands to help share your rr-cache.
         -g, --git-dir DIR                The location of your rr-cache .git dir, defaults to .git/rr-cache/.git.
         -b, --branch NAME                The name of the branch your rr-cache is stored in, defaults to rr-cache.
         -r, --remote NAME                The name of the remote to use when getting the latest rr-cache, defaults to origin.
+	-w, --whitelist-file-name NAME'	 Specify the white list file of a carriage-return delimited list of branch names to whitelist.
 
 **Sub-commands - Usage:**
 

--- a/lib/git_bpf/commands/init.rb
+++ b/lib/git_bpf/commands/init.rb
@@ -16,6 +16,7 @@ class Init < GitFlow/'init'
     opts.script_dir_name = 'git-bpf'
     opts.remote_name = 'origin'
     opts.rerere_branch = 'rr-cache'
+    opts.whitelist_file_name = ''
 
     [
       ['-d', '--directory-name NAME',
@@ -27,6 +28,9 @@ class Init < GitFlow/'init'
       ['-b', '--rerere-branch NAME',
         "",
         lambda { |n| opts.rerere_branch = n }],
+      ['-w', '--whitelist-file-name NAME',
+        "",
+        lambda { |n| opts.whitelist_file_name = n }],
     ]
   end
 

--- a/lib/git_bpf/commands/recreate-branch.rb
+++ b/lib/git_bpf/commands/recreate-branch.rb
@@ -36,7 +36,9 @@ class RecreateBranch < GitFlow/'recreate-branch'
       ['-r', '--remote NAME',
         "Specify the remote repository to work with. Only works with the -d option.",
         lambda { |n| opts.remote = n }],
-
+      ['-w', '--whitelist-file-name NAME',
+	"Specify the white list file of a carriage-return delimited list of branch names to whitelist.",
+	lambda { |n| opts.whitelist_file_name = n }],
     ]
   end
 

--- a/lib/git_bpf/commands/recreate-branch.rb
+++ b/lib/git_bpf/commands/recreate-branch.rb
@@ -89,7 +89,7 @@ class RecreateBranch < GitFlow/'recreate-branch'
     #
     ohai "1. Processing branch '#{source}' for merge-commits..."
 
-    branches = getMergedBranches(opts.base, source)
+    branches = opts.whitelist_file_name.length > 0 ? getMergedBranches(opts.base, source) : getWhiteListBranches(opts.whitelist_file_name)
 
     if branches.empty?
       terminate "No feature branches detected, '#{source}' matches '#{opts.base}'."
@@ -181,6 +181,15 @@ class RecreateBranch < GitFlow/'recreate-branch'
     else
       git('branch', '-D', tmp_source)
     end
+  end
+
+  def getWhiteListBranches(file)
+    branches = []
+    File.open(file, "r") do |file_handle|
+	file_handle.each_line do |name|
+	branches.push name unless branches.include? name
+    end
+    return branches
   end
 
   def getMergedBranches(base, source)

--- a/lib/git_bpf/commands/recreate-branch.rb
+++ b/lib/git_bpf/commands/recreate-branch.rb
@@ -21,34 +21,34 @@ class RecreateBranch < GitFlow/'recreate-branch'
       ['-a', '--base NAME',
         "A reference to the commit from which the source branch is based, defaults to #{opts.base}.",
         lambda { |n| opts.base = n }],
-      ['-b', '--branch NAME',
-        "Instead of deleting the source branch and replacng it with a new branch of the same name, leave the source branch and create a new branch called NAME.",
-        lambda { |n| opts.branch = n }],
-      ['-x', '--exclude NAME',
-        "Specify a list of branches to be excluded.",
-        lambda { |n| opts.exclude.push(n) }],
-      ['-l', '--list',
-        "Process source branch for merge commits and list them. Will not make any changes to any branches.",
-        lambda { |n| opts.list = true }],
-      ['-d', '--discard',
-        "Discard the existing local source branch and checkout a new source branch from the remote if one exists. If no remote is specified with -r, gitbpf will use the configured remote, or origin if none is configured.",
-        lambda { |n| opts.discard = true }],
-      ['-r', '--remote NAME',
-        "Specify the remote repository to work with. Only works with the -d option.",
-        lambda { |n| opts.remote = n }],
-      ['-w', '--whitelist-file-name NAME',
-	"Specify the white list file of a carriage-return delimited list of branch names to whitelist.",
-	lambda { |n| opts.whitelist_file_name = n }],
-    ]
-  end
+        ['-b', '--branch NAME',
+          "Instead of deleting the source branch and replacng it with a new branch of the same name, leave the source branch and create a new branch called NAME.",
+          lambda { |n| opts.branch = n }],
+          ['-x', '--exclude NAME',
+            "Specify a list of branches to be excluded.",
+            lambda { |n| opts.exclude.push(n) }],
+            ['-l', '--list',
+              "Process source branch for merge commits and list them. Will not make any changes to any branches.",
+              lambda { |n| opts.list = true }],
+              ['-d', '--discard',
+                "Discard the existing local source branch and checkout a new source branch from the remote if one exists. If no remote is specified with -r, gitbpf will use the configured remote, or origin if none is configured.",
+                lambda { |n| opts.discard = true }],
+                ['-r', '--remote NAME',
+                  "Specify the remote repository to work with. Only works with the -d option.",
+                  lambda { |n| opts.remote = n }],
+                  ['-w', '--whitelist-file-name NAME',
+                   "Specify the white list file of a carriage-return delimited list of branch names to whitelist.",
+                   lambda { |n| opts.whitelist_file_name = n }],
+                 ]
+               end
 
-  def execute(opts, argv)
-    if argv.length != 1
-      run('recreate-branch', '--help')
-      terminate
-    end
+               def execute(opts, argv)
+                if argv.length != 1
+                  run('recreate-branch', '--help')
+                  terminate
+                end
 
-    source = argv.pop
+                source = argv.pop
 
     # If no new branch name provided, replace the source branch.
     opts.branch = source if opts.branch == nil
@@ -111,11 +111,11 @@ class RecreateBranch < GitFlow/'recreate-branch'
     puts
     puts "If you see something unexpected check:"
     puts "a) that your '#{source}' branch is up to date"
-    puts "b) if '#{opts.base}' is a branch, make sure it is also up to date."
-    opoo "If there are any non-merge commits in '#{source}', they will not be included in '#{opts.branch}'. You have been warned."
-    if not promptYN "Proceed with #{source} branch recreation?"
-      terminate "Aborting."
-    end
+puts "b) if '#{opts.base}' is a branch, make sure it is also up to date."
+opoo "If there are any non-merge commits in '#{source}', they will not be included in '#{opts.branch}'. You have been warned."
+if not promptYN "Proceed with #{source} branch recreation?"
+  terminate "Aborting."
+end
 
     #
     # 2. Backup existing local source branch.
@@ -186,25 +186,26 @@ class RecreateBranch < GitFlow/'recreate-branch'
   def getWhiteListBranches(file)
     branches = []
     File.open(file, "r") do |file_handle|
-	file_handle.each_line do |name|
-	branches.push name unless branches.include? name
-    end
-    return branches
-  end
+     file_handle.each_line do |name|
+       branches.push name unless branches.include? name
+     end
+   end
+   return branches
+ end
 
-  def getMergedBranches(base, source)
-    branches = []
-    merges = git('rev-list', '--parents', '--merges', '--reverse', "#{base}...#{source}").strip
+ def getMergedBranches(base, source)
+  branches = []
+  merges = git('rev-list', '--parents', '--merges', '--reverse', "#{base}...#{source}").strip
 
-    merges.split("\n").each do |commits|
-      parents = commits.split("\s")
-      commit = parents.shift
+  merges.split("\n").each do |commits|
+    parents = commits.split("\s")
+    commit = parents.shift
 
-      parents.each do |parent|
-        name = git('name-rev', parent, '--name-only').strip
-        alt_base = git('name-rev', base, '--name-only').strip
-        remote_heads = /remote\/\w+\/HEAD/
-        unless name.include? source or name.include? alt_base or name.match remote_heads
+    parents.each do |parent|
+      name = git('name-rev', parent, '--name-only').strip
+      alt_base = git('name-rev', base, '--name-only').strip
+      remote_heads = /remote\/\w+\/HEAD/
+      unless name.include? source or name.include? alt_base or name.match remote_heads
           # Make sure not to include the tilde part of a branch name (e.g. '~2')
           # as this signifies a commit that's behind the head of the branch but
           # we want to merge in the head of the branch.

--- a/lib/git_bpf/commands/recreate-branch.rb
+++ b/lib/git_bpf/commands/recreate-branch.rb
@@ -16,6 +16,7 @@ class RecreateBranch < GitFlow/'recreate-branch'
   def options(opts)
     opts.base = 'master'
     opts.exclude = []
+    opts.whitelist_file_name = ''
 
     [
       ['-a', '--base NAME',

--- a/lib/git_bpf/commands/recreate-branch.rb
+++ b/lib/git_bpf/commands/recreate-branch.rb
@@ -187,7 +187,8 @@ end
   def getWhiteListBranches(file)
     branches = []
     File.open(file, "r") do |file_handle|
-     file_handle.each_line do |name|
+     file_handle.each_line do |branch|
+       name = branch.strip
        branches.push name unless branches.include? name
      end
    end

--- a/lib/git_bpf/commands/recreate-branch.rb
+++ b/lib/git_bpf/commands/recreate-branch.rb
@@ -89,7 +89,7 @@ class RecreateBranch < GitFlow/'recreate-branch'
     #
     ohai "1. Processing branch '#{source}' for merge-commits..."
 
-    branches = opts.whitelist_file_name.length > 0 ? getMergedBranches(opts.base, source) : getWhiteListBranches(opts.whitelist_file_name)
+    branches = opts.whitelist_file_name.length > 0 ? getWhiteListBranches(opts.whitelist_file_name) : getMergedBranches(opts.base, source)
 
     if branches.empty?
       terminate "No feature branches detected, '#{source}' matches '#{opts.base}'."


### PR DESCRIPTION
While using this, we wanted to have a list of branch names to white list rather than determine the branch names to white list using rev-list. This will allow such a feature to exist
