### PR TITLE
Ruby 3.3 compatibility - Changed removed File.exists to File.exist

### DIFF
--- a/lib/git_bpf/commands/init.rb
+++ b/lib/git_bpf/commands/init.rb
@@ -95,7 +95,7 @@ class Init < GitFlow/'init'
 
     scripts = File.join(target.path, '.git', opts.script_dir_name)
 
-    if not File.exists? scripts
+    if not File.exist? scripts
       File.symlink source_path, scripts
     elsif File.symlink? scripts
       opoo "Symbolic link already exists."


### PR DESCRIPTION
Ruby 3.3 removed `File.exists` method, leaving just `File.exist`.
The PR aims to fix this issue.